### PR TITLE
Add ability to search containers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ containers](https://docker.io/).
 
  - This project is based on [cockpit-podman](https://github.com/cockpit-project/cockpit-podman), I ported as much as I could to the docker API, but not everything maps (e.g. pods) and not everything is ported yet.
 
+* Additional fixes:
+- Container search added to cockpit-docker (PR #18 upstream)
+
 # Development dependencies
 
 On Debian/Ubuntu:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ containers](https://docker.io/).
 
  - This project is based on [cockpit-podman](https://github.com/cockpit-project/cockpit-podman), I ported as much as I could to the docker API, but not everything maps (e.g. pods) and not everything is ported yet.
 
-* Additional fixes:
+Additional fixes:
 - Container search added to cockpit-docker (PR #18 upstream)
 
 # Development dependencies

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ On Fedora:
 These commands check out the source and build it into the `dist/` directory:
 
 ```
-git clone https://github.com/cockpit-docker/cockpit-docker
+git clone https://github.com/buffaloexpatbill/cockpit-docker
 cd cockpit-docker
 make
 ```

--- a/src/Containers.jsx
+++ b/src/Containers.jsx
@@ -431,7 +431,31 @@ class Containers extends React.Component {
             emptyCaption = _("No running containers");
 
         if (this.props.containers !== null) {
-            filtered = Object.keys(this.props.containers).filter(id => !(this.props.filter === "running") || ["running", "restarting"].includes(this.props.containers[id].State?.Status));
+            const textFilter = this.props.textFilter.toLowerCase().trim();
+
+            filtered = Object.keys(this.props.containers).filter(id => {
+                const container = this.props.containers[id];
+
+                if (this.props.filter === "running" &&
+                    !["running", "restarting"].includes(container.State?.Status)) {
+                    return false;
+                }
+
+                if (!textFilter)
+                    return true;
+
+                const name = (container.Name || "").toLowerCase();
+                const image = (container.Config?.Image || container.Image || "").toLowerCase();
+                const containerId = (container.Id || "").toLowerCase();
+                const cmd = Array.isArray(container.Config?.Cmd)
+                    ? container.Config.Cmd.join(" ").toLowerCase()
+                    : (container.Config?.Cmd || "").toLowerCase();
+
+                return name.includes(textFilter) ||
+                       image.includes(textFilter) ||
+                       containerId.includes(textFilter) ||
+                       cmd.includes(textFilter);
+            });
 
             const getHealth = id => {
                 const state = this.props.containers[id]?.State;


### PR DESCRIPTION
This is to address Container search bar not working #14
Containers.jsx received the same textFilter prop as Images.jsx but did not apply it when generating the filtered container list. 
This patch applies the filter so the global search box matches container names, images, IDs, and commands.